### PR TITLE
[FIX] Bug fix for signature verification

### DIFF
--- a/IAPReceiptVerifier/Classes/IAPReceiptVerifier.swift
+++ b/IAPReceiptVerifier/Classes/IAPReceiptVerifier.swift
@@ -91,7 +91,7 @@ public struct IAPReceiptVerifier {
 
             if let key = self.key {
                 guard let signatureString = HTTPResponse.allHeaderFields["X-Signature"] as? String,
-                    let signature = Data.init(base64Encoded: signatureString),
+                    let signature = Data(base64Encoded: signatureString),
                     SecKeyVerifySignature(key, algorithm, data as CFData, signature as CFData, &error) else {
                         completion(nil)
                         return

--- a/IAPReceiptVerifier/Classes/IAPReceiptVerifier.swift
+++ b/IAPReceiptVerifier/Classes/IAPReceiptVerifier.swift
@@ -90,8 +90,8 @@ public struct IAPReceiptVerifier {
             }
 
             if let key = self.key {
-                guard let signatureString = HTTPResponse.allHeaderFields["X-Signature"] as? NSString,
-                    let signature = signatureString.data(using: String.Encoding.utf8.rawValue),
+                guard let signatureString = HTTPResponse.allHeaderFields["X-Signature"] as? String,
+                    let signature = Data.init(base64Encoded: signatureString),
                     SecKeyVerifySignature(key, algorithm, data as CFData, signature as CFData, &error) else {
                         completion(nil)
                         return


### PR DESCRIPTION
As the server response header field "X-Signature" is a base64 string, the original code cannot pass `SecKeyVerifySignature`, I just change it to `Data.init(base64Encoded: signatureString)` to initialize the signature data, everything works fine in my case. Please verify it, thanks! ;-)