### PR TITLE
added completion with return value nil

### DIFF
--- a/IAPReceiptVerifier/Classes/IAPReceiptVerifier.swift
+++ b/IAPReceiptVerifier/Classes/IAPReceiptVerifier.swift
@@ -68,6 +68,7 @@ public struct IAPReceiptVerifier {
     public func verify(completion: @escaping (Receipt?) -> ()) {
         guard let receiptURL = Bundle.main.appStoreReceiptURL,
             let receiptData = try? Data(contentsOf: receiptURL) else {
+                completion(nil)
                 return
         }
 


### PR DESCRIPTION
In the rare case that the data return of the receipt is not possible I would complete(nil). This makes it simpler to handle the error more easily.